### PR TITLE
Enable new file creation in advanced agent

### DIFF
--- a/tests/test_agentic_chat.py
+++ b/tests/test_agentic_chat.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+
+from groq_agent.agentic_chat import AgenticChat
+from groq_agent.config import ConfigurationManager
+
+
+class DummyAPI:
+    def __init__(self):
+        pass
+
+
+class DummyFileOps:
+    def __init__(self):
+        self.created = None
+
+    def create_file_from_prompt(self, file_path, model, prompt, file_type=None):
+        self.created = (file_path, model, prompt, file_type)
+        Path(file_path).write_text("generated content")
+        return True
+
+
+def test_detects_make_keyword(tmp_path):
+    os.chdir(tmp_path)
+    config = ConfigurationManager(config_dir=tmp_path / "cfg")
+    agent = AgenticChat(config, DummyAPI())
+    assert agent._is_file_modification_request("make a website")
+
+
+def test_creates_file_when_none_found(tmp_path, monkeypatch):
+    os.chdir(tmp_path)
+    config = ConfigurationManager(config_dir=tmp_path / "cfg")
+    agent = AgenticChat(config, DummyAPI())
+    agent.file_ops = DummyFileOps()
+    monkeypatch.setattr("groq_agent.agentic_chat.Prompt.ask", lambda *args, **kwargs: "index.html")
+    response = agent._handle_file_modification_request("make a website listing schools")
+    assert agent.file_ops.created[0] == "index.html"
+    assert "Created new file" in response
+    assert Path("index.html").exists()


### PR DESCRIPTION
## Summary
- broaden modification keyword detection to catch "make", "build" and similar phrases
- auto-create files when advanced agent can't find a target, prompting for path and tracking change
- add tests for agentic chat file creation and keyword detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66bcef5dc832a87f42b54247646f8